### PR TITLE
Fix typo in slide "Resultierende Projektstruktur"

### DIFF
--- a/PITCHME.md
+++ b/PITCHME.md
@@ -59,9 +59,9 @@
 │       ├── meta.yaml
 │       └── hash.md5
 ├── company
-│       ├── init__.py
+│       ├── __init__.py
 │       └── namespace
-│           ├── init__.py
+│           ├── __init__.py
 │           └── project
 │               ├── your_code.py
 │               └── __init__.py


### PR DESCRIPTION
- init__.py was missing leading __ at two places